### PR TITLE
Change semantics of reconnect and session invalid

### DIFF
--- a/src/main/scala/dissonance/Discord.scala
+++ b/src/main/scala/dissonance/Discord.scala
@@ -70,7 +70,7 @@ class Discord(token: String, httpClient: Client[IO], wsClient: WSClient[IO])(imp
       }
       .map(decode[ControlMessage])
       .rethrow
-      .evalMap(controlMessage => handleEvents(controlMessage, connection, intents, state))
+      .parEvalMap(Int.MaxValue)(controlMessage => handleEvents(controlMessage, connection, intents, state))
       .takeWhile(result => !result.terminate)
       .collect { case Result(Some(event)) => event }
       .concurrently(heartbeat(connection, state.interval, state.sequenceNumber, state.acks))

--- a/src/main/scala/dissonance/Discord.scala
+++ b/src/main/scala/dissonance/Discord.scala
@@ -13,7 +13,7 @@ import dissonance.model.identify.{Identify, IdentifyConnectionProperties}
 import dissonance.model.intents.Intent
 import dissonance.utils._
 import fs2.concurrent.Queue
-import fs2.{Pipe, Stream}
+import fs2.Stream
 import io.circe.Json
 import io.circe.parser._
 import io.circe.syntax._

--- a/src/main/scala/dissonance/model/Errors.scala
+++ b/src/main/scala/dissonance/model/Errors.scala
@@ -3,8 +3,6 @@ package dissonance.model
 import scala.util.control.NoStackTrace
 
 object Errors {
-  case class SessionInvalid(resumable: Boolean)                     extends Throwable(s"resumable: $resumable") with NoStackTrace
   case class ConnectionClosedWithError(status: Int, reason: String) extends Throwable(s"status: $status, reason: $reason") with NoStackTrace
   case object NoHeartbeatAck                                        extends Throwable with NoStackTrace
-  case object ReconnectReceived                                     extends Throwable with NoStackTrace
 }


### PR DESCRIPTION
They are expected as part of normal operation with the API and should not be thought of as errors
closes #42 