### PR TITLE
Added method to get the message response from the `executeWebhook`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ metals.sbt
 .metals/
 .bloop
 .idea/
+%LOCALAPPDATA%/

--- a/core/src/main/scala/dissonance/DiscordClient.scala
+++ b/core/src/main/scala/dissonance/DiscordClient.scala
@@ -231,18 +231,21 @@ class DiscordClient(token: String, client: Client[IO])(implicit cs: ContextShift
         )
       )
 
+  def executeWebhookWithResponse(webhook: Webhook, webhookMessage: WebhookMessage): IO[Message] =
+    client.expect[Message](createExecuteWebhookRequest(webhook, webhookMessage, wait = true))
+
+  def executeWebhook(webhook: Webhook, webhookMessage: WebhookMessage): IO[Status] =
+    client.status(createExecuteWebhookRequest(webhook, webhookMessage, wait = false))
+
   // TODO: Handle uploading files which requires multipart/form-data
-  def executeWebhook(webhook: Webhook, wait: Option[Boolean], webhookMessage: WebhookMessage): IO[Status] =
-    client
-      .status(
-        POST(
-          webhookMessage.asJson,
-          apiEndpoint
-            .addPath(s"webhooks/${webhook.id}/${webhook.token.get}")
-            .withQueryParam("wait", wait.getOrElse(false)),
-          headers(token)
-        )
-      )
+  private def createExecuteWebhookRequest(webhook: Webhook, webhookMessage: WebhookMessage, wait: Boolean): IO[Request[IO]] =
+    POST(
+      webhookMessage.asJson,
+      apiEndpoint
+        .addPath(s"webhooks/${webhook.id}/${webhook.token.get}")
+        .withQueryParam("wait", wait),
+      headers(token)
+    )
 
   // TODO: Add Slack and Github Webhooks
 }


### PR DESCRIPTION
Added method to get the message response from the `executeWebhook` call. This is useful if you want to acquire the message id from a webhook to be able to delete the message later.